### PR TITLE
Add functionality to return to homepage when clicking the ottp:// logo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@next/font": "^14.2.5",
         "next": "14.2.5",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-router-dom": "^6.26.1"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -419,6 +420,14 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.1.tgz",
+      "integrity": "sha512-S45oynt/WH19bHbIXjtli6QmwNYvaz+vtnubvNpNDvUOoA/OWh6j1OikIP3G+v5GHdxyC6EXoChG3HgYGEUfcg==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -3781,6 +3790,36 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/react-router": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.1.tgz",
+      "integrity": "sha512-kIwJveZNwp7teQRI5QmwWo39A5bXRyqpH0COKKmPnyD2vBvDwgFXSqDUYtt1h+FEyfnE8eXr7oe0MxRzVwCcvQ==",
+      "dependencies": {
+        "@remix-run/router": "1.19.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.1.tgz",
+      "integrity": "sha512-veut7m41S1fLql4pLhxeSW3jlqs+4MtjRLj0xvuCEXsxusJCbs6I8yn9BxzzDX2XDgafrccY6hwjmd/bL54tFw==",
+      "dependencies": {
+        "@remix-run/router": "1.19.1",
+        "react-router": "6.26.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "@next/font": "^14.2.5",
     "next": "14.2.5",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-router-dom": "^6.26.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/components/Header/index.tsx
+++ b/src/app/components/Header/index.tsx
@@ -1,9 +1,13 @@
+"use client";
+
 import { PropsWithChildren } from "react";
+import { Link } from 'react-router-dom';
+
 
 export const Header: React.FC<PropsWithChildren<{}>> = ({ children }) => {
   return (
     <div className="flex justify-between">
-      <div className="text-2xl text-blue-800">ottp://</div>
+     <Link to="/" className="text-2xl text-blue-800">ottp://</Link>
       <button className="p-2 bg-black text-white">SIGN IN</button>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,8 @@
+"use client";
+
 import { PageContainer } from "@/app/components/PageLayout";
+import { BrowserRouter } from 'react-router-dom';
+
 import {
   Footer,
   Header,
@@ -11,6 +15,7 @@ import { posts } from "@/constants/mocks/postsMock";
 
 export default function Home() {
   return (
+    <BrowserRouter>
     <main>
       <PageContainer>
         <Header />
@@ -25,5 +30,6 @@ export default function Home() {
       </PageContainer>
       <Footer />
     </main>
+  </BrowserRouter>
   );
 }


### PR DESCRIPTION
This PR introduces a fix to enable users to navigate back to the homepage when they click on the ottp:// logo in the header. 

The fix wraps the ottp:// logo inside a <Link> component provided by react-router-dom, allowing navigation without a full page reload.

How to Test:
- Run the project on localhost:3000.
- Click the ottp:// logo in the header.
- Verify that it takes you back to the homepage without a page reload.

